### PR TITLE
build: gzip tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ build/smocker.tar.gz:
 	$(MAKE) build
 	yarn install --frozen-lockfile --ignore-scripts
 	yarn build
-	cd build/; tar -cvf smocker.tar.gz *
+	cd build/; tar -czvf smocker.tar.gz *
 
 .PHONY: release
 release: build/smocker.tar.gz


### PR DESCRIPTION
The tar command currently used to create the release `smocker.tar.gz` files isn't compressing the archives, so add the `-z` in there. This should reduce archive sizes from around 32mb to 10-15mb (compressing a released tarball is usually 10mb, my local builds are 15mb, so might vary depending on who runs the build) and not lead to any confusion when folks run `tar -xzf smocker.tar.gz` and find out that it's not compressed.

Current instructions using `tar xf` don't need to be updated since that will detect if the archive is compressed.